### PR TITLE
docs: move license badge to top of readme

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,5 +1,6 @@
 # vela-kubernetes
 
+[![license](https://img.shields.io/crates/l/gl.svg)](../LICENSE)
 [![GoDoc](https://godoc.org/github.com/go-vela/vela-kubernetes?status.svg)](https://godoc.org/github.com/go-vela/vela-kubernetes)
 [![Go Report Card](https://goreportcard.com/badge/go-vela/vela-kubernetes)](https://goreportcard.com/report/go-vela/vela-kubernetes)
 [![codecov](https://codecov.io/gh/go-vela/vela-kubernetes/branch/master/graph/badge.svg)](https://codecov.io/gh/go-vela/vela-kubernetes)
@@ -30,4 +31,4 @@ Please see our [support](SUPPORT.md) documentation for further instructions.
 Copyright (c) 2020 Target Brands, Inc.
 ```
 
-[![license](https://img.shields.io/crates/l/gl.svg)](LICENSE)
+[Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)


### PR DESCRIPTION
This PR attempts to make the README badge for our license more visible 👍 