### PR TITLE
chore: convert true to always pull policy

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -16,7 +16,7 @@ Sample of applying Kubernetes files:
 steps:
   - name: kubernetes
     image: target/vela-kubernetes:v0.1.0
-    pull: true
+    pull: always
     parameters:
       action: apply
       files: [ kubernetes/common, kubernetes/dev/deploy.yml ]
@@ -28,7 +28,7 @@ Sample of pretending to apply Kubernetes files:
 steps:
   - name: kubernetes
     image: target/vela-kubernetes:v0.1.0
-    pull: true
+    pull: always
     parameters:
       action: apply
 +     dry_run: true
@@ -41,7 +41,7 @@ Sample of patching containers in Kubernetes files:
 steps:
   - name: kubernetes
     image: target/vela-kubernetes:v0.1.0
-    pull: true
+    pull: always
     parameters:
       action: patch
       files: [ kubernetes/common, kubernetes/dev/deploy.yml ]
@@ -56,7 +56,7 @@ Sample of pretending to patch containers in Kubernetes files:
 steps:
   - name: kubernetes
     image: target/vela-kubernetes:v0.1.0
-    pull: true
+    pull: always
     parameters:
       action: patch
 +     dry_run: true
@@ -72,7 +72,7 @@ Sample of watching the status of resources:
 steps:
   - name: kubernetes
     image: target/vela-kubernetes:v0.1.0
-    pull: true
+    pull: always
     parameters:
       action: status
       statuses: [ sample ]
@@ -88,7 +88,7 @@ You can use Vela secrets to substitute sensitive values at runtime:
 steps:
   - name: kubernetes
     image: target/vela-kubernetes:v0.1.0
-    pull: true
+    pull: always
 +   secrets: [ kube_config ]
     parameters:
       action: apply

--- a/DOCS.md
+++ b/DOCS.md
@@ -8,14 +8,14 @@ Registry: https://hub.docker.com/r/target/vela-kubernetes
 
 ## Usage
 
-_The plugin supports reading all parameters via environment variables or files. Values set as a file take precedence over default values set from the environment._
+**NOTE: It is not recommended to use `latest` as the tag for the Docker image. Users should use a semantically versioned tag instead.**
 
 Sample of applying Kubernetes files:
 
 ```yaml
 steps:
   - name: kubernetes
-    image: target/vela-kubernetes:v0.1.0
+    image: target/vela-kubernetes:latest
     pull: always
     parameters:
       action: apply
@@ -27,7 +27,7 @@ Sample of pretending to apply Kubernetes files:
 ```diff
 steps:
   - name: kubernetes
-    image: target/vela-kubernetes:v0.1.0
+    image: target/vela-kubernetes:latest
     pull: always
     parameters:
       action: apply
@@ -40,7 +40,7 @@ Sample of patching containers in Kubernetes files:
 ```yaml
 steps:
   - name: kubernetes
-    image: target/vela-kubernetes:v0.1.0
+    image: target/vela-kubernetes:latest
     pull: always
     parameters:
       action: patch
@@ -55,7 +55,7 @@ Sample of pretending to patch containers in Kubernetes files:
 ```diff
 steps:
   - name: kubernetes
-    image: target/vela-kubernetes:v0.1.0
+    image: target/vela-kubernetes:latest
     pull: always
     parameters:
       action: patch
@@ -71,7 +71,7 @@ Sample of watching the status of resources:
 ```yaml
 steps:
   - name: kubernetes
-    image: target/vela-kubernetes:v0.1.0
+    image: target/vela-kubernetes:latest
     pull: always
     parameters:
       action: status
@@ -87,7 +87,7 @@ You can use Vela secrets to substitute sensitive values at runtime:
 ```diff
 steps:
   - name: kubernetes
-    image: target/vela-kubernetes:v0.1.0
+    image: target/vela-kubernetes:latest
     pull: always
 +   secrets: [ kube_config ]
     parameters:
@@ -100,6 +100,11 @@ steps:
 ```
 
 ## Parameters
+
+**NOTE:**
+
+* the plugin supports reading all parameters via environment variables or files
+* values set from a file take precedence over values set from the environment
 
 The following parameters are used to configure the image:
 


### PR DESCRIPTION
This PR updates the existing docs for the `pull` attribute to match the newly created pull policies.

To accomplish this, I performed a find and replace for converting

```
pull: true
```

to

```
pull: always
```

Also found in this PR is updating the tag for the Docker image we reference to `latest` 👍 