### PR TITLE
chore: bump kubectl version to 1.24.0

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -155,7 +155,7 @@ The following parameters are used to configure the image:
 | `log_level`   | set the log level for the plugin                                | `true`   | `info`            | `PARAMETER_LOG_LEVEL`<br>`KUBERNETES_LOG_LEVEL`            |
 | `namespace`   | Kubernetes namespace from the configuration file                | `false`  | `N/A`             | `PARAMETER_NAMESPACE`<br>`KUBERNETES_NAMESPACE`            |
 | `path`        | path to configuration file for communication with Kubernetes    | `false`  | `N/A`             | `PARAMETER_PATH`<br>`KUBERNETES_PATH`                      |
-| `version`     | version of the `kubectl` CLI to install                         | `false`  | `v1.17.0`         | `PARAMETER_VERSION`<br>`KUBERNETES_VERSION`                |
+| `version`     | version of the `kubectl` CLI to install                         | `false`  | `v1.24.0`         | `PARAMETER_VERSION`<br>`KUBERNETES_VERSION`                |
 
 #### Apply
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # set a global Docker argument for the default CLI version
 #
 # https://github.com/moby/moby/issues/37345
-ARG KUBECTL_VERSION=v1.17.0
+ARG KUBECTL_VERSION=v1.24.0
 
 ###############################################################################
 ##    docker build --no-cache --target binary -t vela-kubernetes:binary .    ##


### PR DESCRIPTION
reviewed changes between kubectl versions and didn't see anything that seemed incompatible. there was a brief period where `dry_run` was changed to not be boolean, but the functionality was later restored for the time being.