### PR TITLE
Adds --short to silence deprecation warning

### DIFF
--- a/cmd/vela-kubernetes/command.go
+++ b/cmd/vela-kubernetes/command.go
@@ -62,7 +62,7 @@ func versionCmd(c *Config) *exec.Cmd {
 	}
 
 	// add flag for version kubectl command
-	flags = append(flags, "version")
+	flags = append(flags, "version", "--short")
 
 	return exec.Command(_kubectl, flags...)
 }

--- a/cmd/vela-kubernetes/command_test.go
+++ b/cmd/vela-kubernetes/command_test.go
@@ -40,6 +40,7 @@ func TestKubernetes_versionCmd(t *testing.T) {
 		fmt.Sprintf("--context=%s", c.Context),
 		fmt.Sprintf("--namespace=%s", c.Namespace),
 		"version",
+		"--short",
 	)
 
 	got := versionCmd(c)


### PR DESCRIPTION
Seen in a run:

> WARNING: This version information is deprecated and will be replaced with the
> output from kubectl version --short.  Use --output=yaml|json to get the full
> version.