### PR TITLE
update kubectl and add gcloud auth plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # set a global Docker argument for the default CLI version
 #
 # https://github.com/moby/moby/issues/37345
-ARG KUBECTL_VERSION=v1.24.0
+ARG KUBECTL_VERSION=v1.24.12
 
 ###############################################################################
 ##    docker build --no-cache --target binary -t vela-kubernetes:binary .    ##
@@ -27,6 +27,14 @@ FROM alpine as certs
 
 RUN apk add --update --no-cache ca-certificates
 
+#############################################################################
+##    docker build --no-cache --target gcloud -t vela-kubernetes:gcloud .    ##
+#############################################################################
+
+FROM gcr.io/google.com/cloudsdktool/google-cloud-cli:alpine as gcloud
+
+RUN gcloud components install gke-gcloud-auth-plugin
+
 ##############################################################
 ##    docker build --no-cache -t vela-kubernetes:local .    ##
 ##############################################################
@@ -40,6 +48,8 @@ ENV PLUGIN_KUBECTL_VERSION=${KUBECTL_VERSION}
 COPY --from=binary /bin/kubectl /bin/kubectl
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+COPY --from=gcloud /google-cloud-sdk/bin/gke-gcloud-auth-plugin /bin/gke-gcloud-auth-plugin
 
 COPY release/vela-kubernetes /bin/vela-kubernetes
 


### PR DESCRIPTION
# Changes:
1. GKE requires new auth plugin, see https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke
2. Update Kubectl to the latest patch [1.24](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#v12412)